### PR TITLE
added button type to avoid submitting forms unintentionally

### DIFF
--- a/src/modules/components/button/template.html
+++ b/src/modules/components/button/template.html
@@ -1,4 +1,4 @@
-<button class='ng2-dropdown-button' (click)="toggleMenu()">
+<button class='ng2-dropdown-button' type="button" (click)="toggleMenu()">
     <ng-content></ng-content>
 
     <span class="caret" [hidden]="!showCaret"></span>


### PR DESCRIPTION
Found that when using the ng-material-select component, forms were being submitted if the select lived inside of a <form>. Fixed this by giving the button a type.