### PR TITLE
Fix hardcoded menu item hierarchy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-material-dropdown",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Angular material-like dropdown component",
   "scripts": {
     "prepublish": "npm run build",

--- a/src/modules/components/menu/ng2-dropdown-menu.ts
+++ b/src/modules/components/menu/ng2-dropdown-menu.ts
@@ -86,7 +86,7 @@ export class Ng2DropdownMenu {
      * @name items
      * @type {QueryList<Ng2MenuItem>}
      */
-    @ContentChildren(Ng2MenuItem) public items: QueryList<Ng2MenuItem>;
+    @ContentChildren(Ng2MenuItem, { descendants: true }) public items: QueryList<Ng2MenuItem>;
 
     private position: ClientRect;
 


### PR DESCRIPTION
Added descendants option to make possible inject own dom-elements between ng2-dropdown-menu and ng2-menu-item components.