### PR TITLE
fix: respect dynamic setting on dropdown menu change

### DIFF
--- a/src/modules/components/menu/ng2-dropdown-menu.ts
+++ b/src/modules/components/menu/ng2-dropdown-menu.ts
@@ -256,7 +256,7 @@ export class Ng2DropdownMenu {
         const element = this.getMenuElement();
         const position = this.calcPositionOffset(this.position);
 
-        if (position) {
+        if (dynamic && position) {
             this.renderer.setElementStyle(element, 'top', position.top.toString());
             this.renderer.setElementStyle(element, 'left', position.left.toString());
         }


### PR DESCRIPTION
Dynamic setting is not used in onChangeMenu, causing an issue with dropdown moving on hover.
Fixes #44