### PR TITLE
Fix animations in IE11

### DIFF
--- a/src/modules/components/menu/ng2-dropdown-menu.ts
+++ b/src/modules/components/menu/ng2-dropdown-menu.ts
@@ -28,22 +28,20 @@ import { DropdownStateService } from '../../services/dropdown-state.service';
     animations: [
         trigger('fade', [
             state('visible', style(
-                {display: 'block', height: '*', width: '*'}
+                {display: 'block', opacity: 1, height: '*', width: '*'}
             )),
             state('hidden', style(
-                {display: 'none', overflow: 'hidden', height: 0, width: 0}
+                {display: 'none', opacity: 0, overflow: 'hidden', height: 0, width: 0}
             )),
             transition('hidden => visible', [
-                animate('250ms ease-in', keyframes([
-                    style({opacity: 0, offset: 0}),
-                    style({opacity: 1, offset: 1, height: '*', width: '*'}),
-                ]))
+                animate('250ms ease-in',
+                    style({opacity: 1, height: '*', width: '*'})
+                )
             ]),
             transition('visible => hidden', [
-                animate('350ms ease-out', keyframes([
-                    style({opacity: 1, offset: 0}),
-                    style({opacity: 0, offset: 1, width: '0', height: '0'}),
-                ]))
+                animate('350ms ease-out',
+                    style({opacity: 0, width: 0, height: 0})
+                )
             ])
         ]),
         trigger('opacity', [


### PR DESCRIPTION
Hi, so it seems that animations don't work properly in IE11 and I just changed them so it would work and it seems to me that the animation are equivalent (be great to here some feedback on that).

Initially I've done this in order to use it in ngx-chips, so I would be greatful if you use it and also make a release of ngx-chips (in the meantime I'll just use it myself in a fork). I guess that would fix this issue: https://github.com/Gbuomprisco/ngx-chips/issues/787

Thanks for your work!