### PR TITLE
Fix animations in Safari (Angular >7.2.4 and 8)

### DIFF
--- a/src/modules/components/menu/ng2-dropdown-menu.ts
+++ b/src/modules/components/menu/ng2-dropdown-menu.ts
@@ -28,10 +28,10 @@ import { DropdownStateService } from '../../services/dropdown-state.service';
     animations: [
         trigger('fade', [
             state('visible', style(
-                {display: 'block', opacity: 1, height: '*', width: '*'}
+                {opacity: 1, height: '*', width: '*'}
             )),
             state('hidden', style(
-                {display: 'none', opacity: 0, overflow: 'hidden', height: 0, width: 0}
+                {opacity: 0, overflow: 'hidden', height: 0, width: 0}
             )),
             transition('hidden => visible', [
                 animate('250ms ease-in',


### PR DESCRIPTION
A simple trick to fix annoying issue in Angular 7.2+ when a dropdown list of available tags on Safari never appears
https://github.com/Gbuomprisco/ngx-chips/issues/877

See also:
https://github.com/angular/angular/issues/29371

I tested this in the `ngx-chips` component (2.0.2).