### PR TITLE
Fixed opening dropdown overflowing window

### DIFF
--- a/demo-app/src/app.component.html
+++ b/demo-app/src/app.component.html
@@ -169,4 +169,21 @@
       </ng2-dropdown-menu>
     </ng2-dropdown>
   </div>
+
+  <div>
+    <h2>
+      Dropdown with a lot of items to drop up
+    </h2>
+
+    <ng2-dropdown>
+      <ng2-dropdown-button>
+        Open Menu
+      </ng2-dropdown-button>
+      <ng2-dropdown-menu>
+        <ng2-menu-item *ngFor="let i of count(40)">
+          I am not going to close the menu
+        </ng2-menu-item>
+      </ng2-dropdown-menu>
+    </ng2-dropdown>
+  </div>
 </main>

--- a/demo-app/src/app.component.ts
+++ b/demo-app/src/app.component.ts
@@ -7,4 +7,12 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   pages = ['Home', 'Explore', 'Help'];
+
+  public count(itemCount: number): number[] {
+      const numbers: number[] = [];
+      for (let i = 0; i < itemCount; i++) {
+          numbers.push(i);
+      }
+      return numbers;
+  }
 }

--- a/src/modules/components/menu/ng2-dropdown-menu.ts
+++ b/src/modules/components/menu/ng2-dropdown-menu.ts
@@ -4,7 +4,8 @@ import {
     Renderer2,
     ContentChildren,
     QueryList,
-    Input
+    Input,
+    ViewChild
 } from '@angular/core';
 
 import {
@@ -33,11 +34,14 @@ import { DropdownStateService } from '../../services/dropdown-state.service';
             [style.z-index]="zIndex"
             [@fade]="dropdownState.menuState.toString()"
         >
-            <div
-                class="ng2-dropdown-menu__options-container"
-                [@opacity]="dropdownState.menuState.toString()"
-            >
-                <ng-content></ng-content>
+            <!-- This extra level of div is to gauge the actual clientHeight during animation -->
+            <div class="ng2-dropdown-menu-container" #menuContainer>
+                <div
+                    class="ng2-dropdown-menu__options-container"
+                    [@opacity]="dropdownState.menuState.toString()"
+                >
+                    <ng-content></ng-content>
+                </div>
             </div>
         </div>
 
@@ -126,6 +130,7 @@ export class Ng2DropdownMenu {
     public items!: QueryList<Ng2MenuItem>;
 
     private position: ClientRect;
+    @ViewChild('menuContainer', { static: false }) private menuContainer?: ElementRef;
 
     private listeners = {
         arrowHandler: undefined,
@@ -214,13 +219,6 @@ export class Ng2DropdownMenu {
     }
 
     /**
-     * @name getMenuElement
-     */
-    private getMenuElement(): Element {
-        return this.element.nativeElement.children[0];
-    }
-
-    /**
      * @name calcPositionOffset
      * @param position
      */
@@ -228,11 +226,12 @@ export class Ng2DropdownMenu {
         const wd = typeof window !== 'undefined' ? window : undefined;
         const dc = typeof document !== 'undefined' ? document : undefined;
 
-        if (!wd || !dc || !position) {
+        const element = this.menuContainer && this.menuContainer.nativeElement;
+
+        if (!wd || !dc || !position || !element) {
             return;
         }
 
-        const element = this.getMenuElement();
         const supportPageOffset = wd.pageXOffset !== undefined;
         const isCSS1Compat = (dc.compatMode || '') === 'CSS1Compat';
 
@@ -304,7 +303,7 @@ export class Ng2DropdownMenu {
     }
 
     public updateOnChange(dynamic = true) {
-        const element = this.getMenuElement();
+        const element = this.element.nativeElement.children[0];
         const position = this.calcPositionOffset(this.position);
 
         if (position) {

--- a/src/modules/components/menu/style.scss
+++ b/src/modules/components/menu/style.scss
@@ -2,6 +2,10 @@
     display: block;
 }
 
+.ng2-dropdown-menu-container {
+    max-height: 400px;
+}
+
 .ng2-dropdown-menu {
     overflow-y: auto;
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
@@ -11,7 +15,6 @@
     background: #fff;
     border-radius: 1px;
 
-    max-height: 400px;
     width: 260px;
     min-height: 0;
 


### PR DESCRIPTION
When opening a dropdown at the bottom of a window it would cause the window to become bigger rather than drop upwards. However, after scrolling the dropdown would then move up. This was caused by the animations having the height set to 0 when the initial calculation was performed.

This resolves the issue reported in #44, although doesn't add the requested feature.